### PR TITLE
Do not recreate manifests if they exist

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -124,11 +124,14 @@ func CreateStaticPodFiles(manifestDir string, cfg *kubeadmapi.ClusterConfigurati
 		}
 
 		// writes the StaticPodSpec to disk
-		if err := staticpodutil.WriteStaticPodToDisk(componentName, manifestDir, spec); err != nil {
-			return errors.Wrapf(err, "failed to create static pod manifest file for %q", componentName)
+		if !staticpodutil.CheckStaticPodExists(componentName, manifestDir) {
+			if err := staticpodutil.WriteStaticPodToDisk(componentName, manifestDir, spec); err != nil {
+				return errors.Wrapf(err, "failed to create static pod manifest file for %q", componentName)
+			}
+			klog.V(1).Infof("[control-plane] wrote static Pod manifest for component %q to %q\n", componentName, kubeadmconstants.GetStaticPodFilepath(componentName, manifestDir))
+	  } else {
+			klog.V(1).Infof("[control-plane] using the existing static Pod manifest for component %q\n", componentName)
 		}
-
-		klog.V(1).Infof("[control-plane] wrote static Pod manifest for component %q to %q\n", componentName, kubeadmconstants.GetStaticPodFilepath(componentName, manifestDir))
 	}
 
 	return nil

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -53,11 +53,14 @@ func CreateLocalEtcdStaticPodManifestFile(manifestDir string, nodeName string, c
 	spec := GetEtcdPodSpec(cfg, endpoint, nodeName, []etcdutil.Member{})
 
 	// writes etcd StaticPod to disk
-	if err := staticpodutil.WriteStaticPodToDisk(kubeadmconstants.Etcd, manifestDir, spec); err != nil {
-		return err
+	if !staticpodutil.CheckStaticPodExists(kubeadmconstants.Etcd, manifestDir) {
+		if err := staticpodutil.WriteStaticPodToDisk(kubeadmconstants.Etcd, manifestDir, spec); err != nil {
+			return err
+		}
+		klog.V(1).Infof("[etcd] wrote Static Pod manifest for a local etcd member to %q\n", kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.Etcd, manifestDir))
+	} else {
+		klog.V(1).Infoln("[etcd] using the existing Static Pod manifest for a local etcd member\n")
 	}
-
-	klog.V(1).Infof("[etcd] wrote Static Pod manifest for a local etcd member to %q\n", kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.Etcd, manifestDir))
 	return nil
 }
 

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -297,7 +297,7 @@ func (fac FileAvailableCheck) Check() (warnings, errorList []error) {
 	return nil, errorList
 }
 
-// FileExistingCheck checks that the given file does not already exist.
+// FileExistingCheck checks that the given file does already exist.
 type FileExistingCheck struct {
 	Path  string
 	Label string

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -905,7 +905,6 @@ func RunInitNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfigura
 		FileAvailableCheck{Path: kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.KubeAPIServer, manifestsDir)},
 		FileAvailableCheck{Path: kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.KubeControllerManager, manifestsDir)},
 		FileAvailableCheck{Path: kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.KubeScheduler, manifestsDir)},
-		FileAvailableCheck{Path: kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.Etcd, manifestsDir)},
 		HTTPProxyCheck{Proto: "https", Host: cfg.LocalAPIEndpoint.AdvertiseAddress},
 		HTTPProxyCIDRCheck{Proto: "https", CIDR: cfg.Networking.ServiceSubnet},
 		HTTPProxyCIDRCheck{Proto: "https", CIDR: cfg.Networking.PodSubnet},
@@ -942,6 +941,7 @@ func RunInitNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfigura
 			PortOpenCheck{port: kubeadmconstants.EtcdListenClientPort},
 			PortOpenCheck{port: kubeadmconstants.EtcdListenPeerPort},
 			DirAvailableCheck{Path: cfg.Etcd.Local.DataDir},
+			FileAvailableCheck{Path: kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.Etcd, manifestsDir)},
 		)
 	}
 

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -165,6 +165,13 @@ func GetExtraParameters(overrides map[string]string, defaults map[string]string)
 	return command
 }
 
+// CheckStaticPodExists checks if a static pod file exists on disk
+func CheckStaticPodExists(componentName, manifestDir string) bool {
+	filename := kubeadmconstants.GetStaticPodFilepath(componentName, manifestDir)
+	_, certErr := os.Stat(filename)
+	return certErr == nil
+}
+
 // WriteStaticPodToDisk writes a static pod file to disk
 func WriteStaticPodToDisk(componentName, manifestDir string, pod v1.Pod) error {
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Implements the following change in behavior/feature:
(1) Prevents the recreation of control-plane and etcd manifests if the files already exist.

Fixes a these small issues:
(2) Moves the check for the etcd manifest to the etcd section so it only happens for local etcd.
(3) Fixes a typo in a docstring.

**Which issue(s) this PR fixes**: 
Fixes kubernetes/kubeadm#1679

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
I put NONE for this being a user-facing change, but I'm not sure how strictly that's defined. I'll write a release note if we need one. 

